### PR TITLE
Added mulitpages for different stocks

### DIFF
--- a/LSTM_model/Home.py
+++ b/LSTM_model/Home.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+st.set_page_config(page_title="Home", page_icon="👋",)
+
+st.sidebar.success("Select a dataset for analysis above.")
+
+st.title("L3Harris Adversarial Data Attack Detection Machine Learning Model")
+
+st.header("Welcome to the L3Harris Senior Capstone Project!")
+st.subheader("To run our model and analyses please choose a dataset from the sidebar")
+st.subheader("Features of our data manipulations include: simulating adversarial attacks, simulating continous retraining with window parsing, hole detection, local outlier factor, unsupervised learning KNN, and Hurst exponent.")
+
+st.caption("Project Name: Colorado University at Boulder 2022-2023 Computer Science Capstone Project for L3Harris Technologies (LSTM Knowledge Transfer from Stock Markets to Orbital Data)")
+st.caption("High-level Objective Statement: Our neural network model will predict historical stock market trends for DJIA, S&P 500, and NASDAQ. Using this existing model we will adapt it to fit the needs of continuous training, anomaly detection, protection against adversarial attacks, as well as explainability of model predictions in the use case of orbital data.")
+st.caption("Background Information: L3Harris Technologies works alongside the US Space Force to track information about the orbits of satellites, rockets, and other space debris. In order to reduce the work orbital analysts have to do, L3Harris Technologies wants to develop a robust ML model that is resistant to different kinds of attacks by potential adversaries, that is tolerant to mistakes made when classifying incoming data, and that can explain decisions to orbital analysts that haven’t worked with the model.")
+st.caption("Successful Outcome Statement: The final revised LSTM model for the stock market predictions will be explainable, robust, and can operate in adversarial environments. The model, as well as a testing injection framework can be transferred and applied to frameworks and conditions in which L3Harris customer’s ML models are developed and deployed within their own production environments.")
+st.caption("Strategic Alignment: This project incorporates Machine Learning and Artificial Intelligence which is a growing field within the industry. Using these techniques, we are able to reduce outliers and create more accurate models. These models will be beneficial for the company given they give the outputs needed for success. Corporate strategies highlight using the most optimal solutions. Optimal solutions come from using models in Machine Learning such as NN to produce respectable outcomes. Throughout this project, we will demonstrate team work, organizational skills, and thus our knowledge in the field. By working in an agile development environment using Trello, we are able to stay aligned with one another and keep track of updates in the project. With weekly meetings with sponsors and TA’s we will be able to keep everyone in the loop and make sure we are on the right path. Along with this, this project will allow us to ask questions and understand the company’s strategies more.")
+st.caption("Key Initiative Alignment: Key initiatives include creating a stand-in domain for the company’s own model for space orbit detection using stock market data. Data will be tracked and analyzed in a model similarly to provide applicable analysis of a model without access to the company’s sensitive data.")

--- a/LSTM_model/LSTM_sim.py
+++ b/LSTM_model/LSTM_sim.py
@@ -55,11 +55,14 @@ class LSTM(nn.Module):
 
 class LSTM_sim():
 
-    def __init__(self, df):
+    def __init__(self, df, filename, start_date, end_date):
         self.df = df
+        self.filename = filename
+        self.start_date = start_date
+        self.end_date = end_date
 
     def simulation(self):
-        st.title("L3 Harris Senior Capstone - Data Input Manipulation of LSTM Model")
+        st.title("LSTM Model Run")
 
         self.get_data_timeseries()
         scaler = self.fill_missing_vals()
@@ -72,7 +75,7 @@ class LSTM_sim():
         # #df_nas.head()
         # df_nas.fillna(method='pad')
 
-        st.subheader("NasDaq Data from 2010-2017, visualizing the close prices")
+        st.subheader(self.filename+" Data from " + self.start_date + " to " + self.end_date + ", visualizing the close prices")
         left_col, right_col = st.columns(2)
         with left_col:
             st.write(self.df)
@@ -204,10 +207,10 @@ class LSTM_sim():
         figure, axes = plt.subplots(figsize=(10, 10))
         axes.xaxis_date()
 
-        axes.plot(self.df[len(self.df)-len(y_test):].index, y_test, color = 'red', label = 'Real NasDaq Stock Price')
-        axes.plot(self.df[len(self.df)-len(y_test):].index, y_test_pred, color = 'blue', label = 'Predicted NasDaq Stock Price')
+        axes.plot(self.df[len(self.df)-len(y_test):].index, y_test, color = 'red', label = 'Real '+ self.filename + ' Stock Price')
+        axes.plot(self.df[len(self.df)-len(y_test):].index, y_test_pred, color = 'blue', label = 'Predicted ' + self.filename + ' NasDaq Stock Price')
         #axes.xticks(np.arange(0,394,50))
-        plt.title('NasDaq Stock Price Prediction')
+        plt.title(self.filename + ' Stock Price Prediction')
         plt.xlabel('Time')
         plt.ylabel('NasDaq Stock Price')
         plt.legend()

--- a/LSTM_model/Pipeline.py
+++ b/LSTM_model/Pipeline.py
@@ -13,14 +13,16 @@ import math
 
 
 class Pipeline():
+    def __init__(self, filename, start_date, end_date):
+        self.filename = filename
+        self.start_date = start_date
+        self.end_date = end_date
+
 
     def run_pipeline(self):
-        filename = 'nasdaq_all.csv'
-        start_date = '2010-01-04'
-        end_date = '2017-01-03'
-        df_temp = pd.read_csv('../stock_data/'+filename, usecols=['Date', 'Close'], na_values=['nan'])
+        df_temp = pd.read_csv('../stock_data/'+self.filename, usecols=['Date', 'Close'], na_values=['nan'])
         df_temp['Date'] = pd.to_datetime(df_temp['Date'])
-        df = df_temp[(df_temp['Date'] >= start_date) & (df_temp['Date'] <= end_date)]
+        df = df_temp[(df_temp['Date'] >= self.start_date) & (df_temp['Date'] <= self.end_date)]
         df.set_index('Date', inplace=True)
 
         #preprocessing steps
@@ -68,14 +70,14 @@ class Pipeline():
             #run fill missing value on cleaned df variable
             win.accepted(judge)
     
-        st.set_page_config(page_title='L3Harris Senior Capstone', page_icon=None, layout="wide", initial_sidebar_state="auto", menu_items=None)
+        #st.set_page_config(page_title='L3Harris Senior Capstone', page_icon=None, layout="wide", initial_sidebar_state="auto", menu_items=None)
 
         st.sidebar.title("Data Manipulations")
 
         st.sidebar.header("K-Nearest Neighbors")
         
 
-        k = KNN_unsupervised.KNN_unsupervised(filename, start_date, end_date)
+        k = KNN_unsupervised.KNN_unsupervised(self.filename, self.start_date, self.end_date)
         manipulated_data = k.run_KNN()
         print(manipulated_data)
 
@@ -117,7 +119,7 @@ class Pipeline():
         #data manipulation steps
 
         #LSTM Model
-        model_sim = LSTM_sim(manipulated_data)
+        model_sim = LSTM_sim(manipulated_data, self.filename, self.start_date, self.end_date)
         model_sim.simulation()
 
         #Model validity checks??
@@ -126,6 +128,9 @@ class Pipeline():
 
 
 ###### RUN THE PIPELINE
+# filename = 'nasdaq_all.csv'
+# start_date = '2010-01-04'
+# end_date = '2017-01-03'
 
-pipeline = Pipeline()
-pipeline.run_pipeline()
+# pipeline = Pipeline(filename, start_date, end_date)
+# pipeline.run_pipeline()

--- a/LSTM_model/pages/1_📈_NASDAQ.py
+++ b/LSTM_model/pages/1_📈_NASDAQ.py
@@ -1,0 +1,14 @@
+import streamlit as st
+from Pipeline import Pipeline
+
+st.set_page_config(page_title="NASDAQ", page_icon="📈")
+
+st.markdown("# NASDAQ")
+st.sidebar.header("NASDAQ")
+
+filename = 'nasdaq_all.csv'
+start_date = '2010-01-04'
+end_date = '2017-01-03'
+
+pipeline = Pipeline(filename, start_date, end_date)
+pipeline.run_pipeline()

--- a/LSTM_model/pages/2_📈_DJIA.py
+++ b/LSTM_model/pages/2_📈_DJIA.py
@@ -1,0 +1,16 @@
+import streamlit as st
+import Pipeline as pl
+
+st.set_page_config(page_title="DJIA", page_icon="📈")
+
+st.markdown("# DJIA")
+st.sidebar.header("DJIA")
+
+# filename = 'djia_2012.csv'
+# start_date = '2013-01-03'
+# end_date = '2017-01-03'
+
+# pipeline = pl(filename, start_date, end_date)
+# pipeline.run_pipeline()
+
+st.write('IN PROGRESS')

--- a/LSTM_model/pages/3_📈_RUSSELL2000.py
+++ b/LSTM_model/pages/3_📈_RUSSELL2000.py
@@ -1,0 +1,14 @@
+import streamlit as st
+from Pipeline import Pipeline
+
+st.set_page_config(page_title="RUSSELL 2000", page_icon="📈")
+
+st.markdown("# RUSSELL 2000")
+st.sidebar.header("RUSSELL 2000")
+
+filename = 'russel2000_all.csv'
+start_date = '2010-01-04'
+end_date = '2017-01-03'
+
+pipeline = Pipeline(filename, start_date, end_date)
+pipeline.run_pipeline()


### PR DESCRIPTION
okay so this merge request is a pretty hefty update:
- implemented multiple pages for running NASDAQ, DJIA, RUSSELL 
- pipeline.py is no longer the home page and is just a class used for running the three datasets thru the whole pipeline
- there is now a pages folder that has the 3 pages for the datasets where just pipeline is run (there is no other efficient way to create the pages bc of the way streamlit works even though the same code is present in these 3 files)
- edited LSTM_sim and Pipeline.py classes to take in filename, start date, end date on initialization to make sure dates and stock index are consistent in the graphs and tables 
- added Home.py which is now our homepage of the app and has the readme from this github repo on it

CANNOT MERGE YET 